### PR TITLE
Correctly Handle Newlines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,9 @@ buildscript {
 apply from: project.buildscript.classLoader.getResource('main.gradle').toURI()
 
 dependencies {
- compile 'se.bjurr.violations:violations-lib:1.+'
- compile 'org.slf4j:slf4j-api:1.7.22'
- compile 'com.github.spullara.mustache.java:compiler:0.9.5'
- testCompile 'junit:junit:4.12'
- testCompile 'org.assertj:assertj-core:2.3.0'
+ implementation 'se.bjurr.violations:violations-lib:1.+'
+ implementation 'org.slf4j:slf4j-api:1.7.22'
+ implementation 'com.github.spullara.mustache.java:compiler:0.9.5'
+ testImplementation 'junit:junit:4.12'
+ testImplementation 'org.assertj:assertj-core:2.3.0'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/se/bjurr/violations/comments/lib/ViolationMustacheFactory.java
+++ b/src/main/java/se/bjurr/violations/comments/lib/ViolationMustacheFactory.java
@@ -1,0 +1,25 @@
+package se.bjurr.violations.comments.lib;
+
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.MustacheException;
+import java.io.IOException;
+import java.io.Writer;
+import se.bjurr.violations.lib.util.StringUtils;
+
+/**
+ * Extends the DefaultMustacheFactory to use an encode method that does not HTML encode the carriage
+ * return and new line characters. HTML Encoding the `\n` and `\r` characters does not display
+ * correctly in GitHub markdown and does not need to be encoded per the HTML RFC.
+ */
+public class ViolationMustacheFactory extends DefaultMustacheFactory {
+
+  @Override
+  public void encode(String value, Writer writer) {
+    try {
+      String encoded = StringUtils.escapeHTML(value);
+      writer.write(encoded);
+    } catch (IOException e) {
+      throw new MustacheException("Unable to encode value", e);
+    }
+  }
+}

--- a/src/main/java/se/bjurr/violations/comments/lib/ViolationRenderer.java
+++ b/src/main/java/se/bjurr/violations/comments/lib/ViolationRenderer.java
@@ -5,7 +5,6 @@ import static se.bjurr.violations.comments.lib.ChangedFileUtils.findChangedFile;
 import static se.bjurr.violations.comments.lib.CommentsCreator.FINGERPRINT;
 import static se.bjurr.violations.comments.lib.CommentsCreator.FINGERPRINT_ACC;
 
-import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
 import java.io.Reader;
@@ -56,7 +55,7 @@ public class ViolationRenderer {
 
   static String createSingleFileCommentContent(
       final ChangedFile changedFile, final Violation violation, final String commentTemplate) {
-    final MustacheFactory mf = new DefaultMustacheFactory();
+    final MustacheFactory mf = new ViolationMustacheFactory();
     Reader templateReader = null;
     final Optional<String> commentTemplateOpt = ofNullable(commentTemplate);
     if (commentTemplateOpt.isPresent() && !commentTemplateOpt.get().isEmpty()) {

--- a/src/test/java/se/bjurr/violations/comments/lib/CommentsCreatorTest.java
+++ b/src/test/java/se/bjurr/violations/comments/lib/CommentsCreatorTest.java
@@ -357,12 +357,6 @@ public class CommentsCreatorTest {
     this.files.add(new ChangedFile("file1", null));
 
     createComments(this.logger, this.violations, this.commentsProvider);
-    System.out.println("---------------------");
-    System.out.println("---------------------");
-    System.out.println(this.createSingleFileComment.size());
-    System.out.println(this.createSingleFileComment.get(0).trim());
-    System.out.println("---------------------");
-    System.out.println("---------------------");
 
     assertThat(this.createSingleFileComment.get(0).trim())
         //

--- a/src/test/java/se/bjurr/violations/comments/lib/CommentsCreatorTest.java
+++ b/src/test/java/se/bjurr/violations/comments/lib/CommentsCreatorTest.java
@@ -161,6 +161,14 @@ public class CommentsCreatorTest {
           .setFile("file2") //
           .setMessage("3333333333") //
           .build();
+  private final Violation violation4 =
+      violationBuilder() //
+          .setParser(ANDROIDLINT) //
+          .setStartLine(1) //
+          .setSeverity(ERROR) //
+          .setFile("file1") //
+          .setMessage("one\ntwo") //
+          .build();
   private final List<String> specifics = new ArrayList<>();
   private String type;
   private String identifier;
@@ -340,6 +348,25 @@ public class CommentsCreatorTest {
     assertThat(this.createSingleFileComment.get(1).trim())
         //
         .isEqualTo(this.asFile("testMarkdownSingleFileCommentWithoutSource.md"));
+  }
+
+  @Test
+  public void testNewLine() throws Exception {
+    this.violations.add(this.violation4);
+
+    this.files.add(new ChangedFile("file1", null));
+
+    createComments(this.logger, this.violations, this.commentsProvider);
+    System.out.println("---------------------");
+    System.out.println("---------------------");
+    System.out.println(this.createSingleFileComment.size());
+    System.out.println(this.createSingleFileComment.get(0).trim());
+    System.out.println("---------------------");
+    System.out.println("---------------------");
+
+    assertThat(this.createSingleFileComment.get(0).trim())
+        //
+        .isEqualTo(this.asFile("testMarkdownSingleFileCommentWithNewLine.md"));
   }
 
   @Test

--- a/src/test/resources/testMarkdownSingleFileCommentWithNewLine.md
+++ b/src/test/resources/testMarkdownSingleFileCommentWithNewLine.md
@@ -1,0 +1,8 @@
+**Reporter**: ANDROIDLINT
+**Severity**: ERROR
+**File**: file1 L1
+
+one
+two
+
+*<this is a auto generated comment from violation-comments-lib F7F8ASD8123FSDF>* *<a985865833>*


### PR DESCRIPTION
Currently the Mustache Templates HTML encodes the newline and carriage return characters - which does not display correctly in GitHub's Markdown. The PR uses the StringUtil encoding method in the `violations-lib`.

Additionally, the gradle wrapper was upgraded to 7.0.2.